### PR TITLE
fix: should be able to specify breadcrumb alias without @ prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+<!-- markdownlint-disable -->
+
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 ## [6.2.0](https://github.com/udayvunnam/xng-breadcrumb/compare/v6.1.0...v6.2.0) (2020-09-07)

--- a/apps/breadcrumb-demo-e2e/src/integration/default.spec.ts
+++ b/apps/breadcrumb-demo-e2e/src/integration/default.spec.ts
@@ -81,4 +81,12 @@ describe('breadcrumb-demo', () => {
       getDefaultBreadcrumbs().contains(`Viewing ${resolvedId} now`);
     });
   });
+
+  it('Should have used alias to skip a breadcrumb', () => {
+    cy.visit('/');
+    cy.get('.navbar-header').contains('Mentees').click();
+    cy.get('bd-mentee-list .mat-card-avatar').eq(0).click();
+    cy.get('.mat-card-actions button').click(); // Mentee Edit route uses set(@menteeEdit, {skip: true})
+    getDefaultBreadcrumbs().contains('edit').should('not.exist');
+  });
 });

--- a/apps/breadcrumb-demo/src/app/mentee/mentee-details/mentee-details.component.ts
+++ b/apps/breadcrumb-demo/src/app/mentee/mentee-details/mentee-details.component.ts
@@ -27,7 +27,6 @@ export class MenteeDetailsComponent implements OnInit {
 
     this.dataService.getMentee(menteeId).subscribe((response) => {
       this.mentee = response;
-      this.breadcrumbService.set('@menteeName', this.mentee.name);
     });
   }
 

--- a/libs/xng-breadcrumb/src/lib/breadcrumb.service.ts
+++ b/libs/xng-breadcrumb/src/lib/breadcrumb.service.ts
@@ -292,7 +292,7 @@ export class BreadcrumbService {
     let updateArgs: [StoreMatcherKey, BreadcrumbDefinition];
 
     if (key.startsWith(ALIAS_PREFIX)) {
-      updateArgs = ['alias', { ...breadcrumbObject, alias: key }];
+      updateArgs = ['alias', { ...breadcrumbObject, alias: key.slice(1) }];
     } else if (key.includes(PATH_PARAM.PREFIX)) {
       updateArgs = [
         'routeRegex',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [the guidelines](https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

We don't need user to specify ~`{breadcrumb: { alias: '@id' } }`~
we just need `{breadcrumb: { alias: 'id' } }` with `breadcrumbService.set('@id', 'MapingLabel')`.

Adding a test to verify this.


Issue Number: fixes https://github.com/udayvunnam/xng-breadcrumb/issues/47

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
