### PR TITLE
improvement: include index and count in xngBreadcrumbItem

### DIFF
--- a/libs/xng-breadcrumb/src/lib/breadcrumb.component.html
+++ b/libs/xng-breadcrumb/src/lib/breadcrumb.component.html
@@ -1,8 +1,12 @@
 <nav aria-label="breadcrumb" class="xng-breadcrumb-root" [ngClass]="class">
   <ol class="xng-breadcrumb-list">
     <ng-container
-      *ngFor="let breadcrumb of breadcrumbs; last as isLast; first as isFirst"
-    >
+      *ngFor="
+        let breadcrumb of breadcrumbs; 
+        last as isLast; 
+        first as isFirst; 
+        index as index; 
+        count as count;">
       <li class="xng-breadcrumb-item">
         <a
           *ngIf="!isLast"
@@ -18,7 +22,9 @@
                 $implicit: breadcrumb.label,
                 info: breadcrumb.info,
                 last: isLast,
-                first: isFirst
+                first: isFirst,
+                index: index,
+                count: count
               }
             "
           ></ng-container>
@@ -35,7 +41,9 @@
                 $implicit: breadcrumb.label,
                 info: breadcrumb.info,
                 last: isLast,
-                first: isFirst
+                first: isFirst,
+                index: index,
+                count: count
               }
             "
           ></ng-container>


### PR DESCRIPTION
## What is this about

include index and count in xngBreadcrumbItem to allow for configurations based on index instead of name or alias.

## PR Checklist

Please check if your PR fulfils the following requirements:

- [x] The commit message follows [the guidelines](https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
