### PR TITLE
fix: use tabindex and listen to keyboard enter since routerLink is no longer used

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: '🐞 Bug report'
-about: Report a bug in Scully
+about: Report a bug in xng-breadcrumb
 title: ''
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: '🧩 Feature request'
-about: Suggest an idea for Scully
+about: Suggest an idea for xng-breadcrumb
 title: ''
 labels: enhancement
 assignees: ''

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
-## What is this about
+# What is this PR about
+
+<!-- ✍️--> A clear and concise description...
 
 ## PR Checklist
 

--- a/libs/xng-breadcrumb/src/lib/breadcrumb.component.html
+++ b/libs/xng-breadcrumb/src/lib/breadcrumb.component.html
@@ -13,9 +13,12 @@
         <a
           *ngIf="!isLast"
           (click)="handleRoute(breadcrumb)"
+          (keydown.enter)="handleRoute(breadcrumb)"
           class="xng-breadcrumb-link"
           [ngClass]="{ 'xng-breadcrumb-link-disabled': breadcrumb.disable }"
           [attr.aria-disabled]="breadcrumb.disable"
+          [attr.tabIndex]="breadcrumb.disable ? -1 : 0"
+          role="button"
         >
           <ng-container
             *ngTemplateOutlet="

--- a/libs/xng-breadcrumb/src/lib/breadcrumb.component.scss
+++ b/libs/xng-breadcrumb/src/lib/breadcrumb.component.scss
@@ -28,6 +28,7 @@
   color: inherit;
   text-decoration: none;
   transition: text-decoration 0.3s;
+  cursor: pointer;
 }
 
 .xng-breadcrumb-link:hover {


### PR DESCRIPTION
## What is this about
use tabindex and listen to keyboard enter since routerLink is no longer used

closes https://github.com/udayvunnam/xng-breadcrumb/issues/66
## PR Checklist

Please check if your PR fulfils the following requirements:

- [x] The commit message follows [the guidelines](https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
