### PR TITLE
fix(accessibility): removed aria-role from the separator

### DIFF
--- a/libs/xng-breadcrumb/src/lib/breadcrumb.component.html
+++ b/libs/xng-breadcrumb/src/lib/breadcrumb.component.html
@@ -67,12 +67,7 @@
         </label>
       </li>
 
-      <li
-        *ngIf="!isLast"
-        class="xng-breadcrumb-separator"
-        aria-hidden="true"
-        role="separator"
-      >
+      <li *ngIf="!isLast" class="xng-breadcrumb-separator" aria-hidden="true">
         <ng-container *ngTemplateOutlet="separatorTemplate"></ng-container>
         <ng-container *ngIf="!separatorTemplate">{{ separator }}</ng-container>
       </li>


### PR DESCRIPTION
The JAWS Screen Reader has a problem with the element containing both - arial-hidden="true"
and role="separator".

Resolves #140

# What is this PR about

The JAWS Screen Reader has a problem with the element containing both - arial-hidden="true"
and role="separator". To solve this issue the property role="separator" has been deleted.

## PR Checklist

Please check if your PR fulfils the following requirements:

- [x] The commit message follows [the guidelines](./contributing.md#commit)
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
