### PR TITLE
docs: fix incorrect link to custom separator page

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -17,7 +17,7 @@
   - [Add icon with label](add-icon-with-label.md)
   - [Use filter to change text case](use-filter.md)
   - [Internationalization](internationalization.md)
-  - [custom seperator](custom-separator.md)
+  - [Custom seperator](custom-separator.md)
 
 - [API](api.md)
 - [Where to define breadcrumbs](where-to-define-breadcrumbs.md)

--- a/docs/custom-separator.md
+++ b/docs/custom-separator.md
@@ -1,4 +1,4 @@
-# Change separator
+# Custom separator
 
 - Breadcrumb uses '/' as the separator by default.
 - To use custom separator pass **separator** as an input to `<xng-breadcrumb>`.


### PR DESCRIPTION
# What is this PR about

This PR fixes the link to the custom separator page in the sidebar of the docs. Currently the link leads to a `404 - not found` page. This was adjusted in this PR.

**To test this locally:**
* Run `yarn serve-docs` ([docsify must be installed globally)](https://docsify.js.org/#/quickstart?id=quick-start)
* Open http://localhost:3000
* Click on the `Custom separator` link in the sidebar

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [the guidelines](./contributing.md#commit)
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
