### PR TITLE
refactor(service): Use type predicate in rxjs filter

### DIFF
--- a/libs/xng-breadcrumb/src/lib/breadcrumb.service.ts
+++ b/libs/xng-breadcrumb/src/lib/breadcrumb.service.ts
@@ -68,12 +68,16 @@ export class BreadcrumbService {
     this.setupBreadcrumbs(this.activatedRoute.snapshot);
 
     this.router.events
-      .pipe(filter((event) => event instanceof GuardsCheckEnd))
+      .pipe(
+        filter(
+          (event): event is GuardsCheckEnd => event instanceof GuardsCheckEnd
+        )
+      )
       .subscribe((event) => {
         // activatedRoute doesn't carry data when shouldReuseRoute returns false
         // use the event data with GuardsCheckEnd as workaround
         // Check for shouldActivate in case where the authGuard returns false the breadcrumbs shouldn't be changed
-        if (event instanceof GuardsCheckEnd && event.shouldActivate) {
+        if (event.shouldActivate) {
           this.setupBreadcrumbs(event.state.root);
         }
       });


### PR DESCRIPTION
# What is this PR about

This uses a type predicate inside the rxjs filter, in the `detectRouteChanges` of the service.
That makes typescript aware of the event's type, so that subsequently the type doesn't have to be checked again.

(I've checked the boxes below, as it's only a refactor, not a fix/feature.

## PR Checklist

Please check if your PR fulfils the following requirements:

- [x] The commit message follows [the guidelines](./contributing.md#commit)
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
