### PR TITLE
fix: Removed role="button" attribute from .xng-breadcrumb-link

### DIFF
--- a/libs/xng-breadcrumb/src/lib/breadcrumb.component.html
+++ b/libs/xng-breadcrumb/src/lib/breadcrumb.component.html
@@ -16,7 +16,6 @@
           [ngClass]="{ 'xng-breadcrumb-link-disabled': breadcrumb.disable }"
           [attr.aria-disabled]="breadcrumb.disable"
           [attr.tabIndex]="breadcrumb.disable ? -1 : 0"
-          role="button"
           rel="noopener noreferrer"
           [routerLink]="
             breadcrumb.routeInterceptor


### PR DESCRIPTION
The a.xng-breadcrumb-link elements in the breadcrumb navigation are interpreted as buttons for assistive technologies due to role="button" attribute, even though they are clearly links (and not buttons). The role="button" attribute should be removed.

# What is this PR about

The a.xng-breadcrumb-link elements in the breadcrumb navigation are interpreted as buttons for assistive technologies due to role="button" attribute, even though they are clearly links (and not buttons). The role="button" attribute has been removed.

## PR Checklist

Please check if your PR fulfils the following requirements:

- [x] The commit message follows [the guidelines](./contributing.md#commit)
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
