### PR TITLE
feat: static query params

### DIFF
--- a/apps/default/src/app/app-routing.module.ts
+++ b/apps/default/src/app/app-routing.module.ts
@@ -3,7 +3,7 @@ import { Routes, RouterModule } from '@angular/router';
 import { PageNotFoundComponent } from './core/page-not-found.component';
 import { HomeComponent } from './home/home.component';
 
-// when deafalt route has no path or breadcrumb diplay home
+// when default route has no path or breadcrumb display home
 export const appRoutes: Routes = [
   {
     path: '',
@@ -16,6 +16,9 @@ export const appRoutes: Routes = [
         routeInterceptor: (routeLink) => {
           return routeLink;
         },
+        staticQueryParams: {
+          fromBreadcrumb: true,
+        },
       },
     },
   },
@@ -27,6 +30,9 @@ export const appRoutes: Routes = [
       breadcrumb: {
         label: 'dashboard',
         info: 'dashboard',
+        staticQueryParams: {
+          fromBreadcrumb: true,
+        },
       },
     },
   },
@@ -37,6 +43,9 @@ export const appRoutes: Routes = [
     data: {
       breadcrumb: {
         info: 'person',
+        staticQueryParams: {
+          fromBreadcrumb: true,
+        },
       },
     },
   },
@@ -48,6 +57,9 @@ export const appRoutes: Routes = [
       breadcrumb: {
         info: 'person_outline',
         label: 'Mentee (Root)',
+        staticQueryParams: {
+          fromBreadcrumb: true,
+        },
       },
     },
   },

--- a/apps/default/src/app/app-routing.module.ts
+++ b/apps/default/src/app/app-routing.module.ts
@@ -17,7 +17,7 @@ export const appRoutes: Routes = [
           return routeLink;
         },
         staticQueryParams: {
-          fromBreadcrumb: true,
+          'from-breadcrumb': true,
         },
       },
     },
@@ -31,7 +31,7 @@ export const appRoutes: Routes = [
         label: 'dashboard',
         info: 'dashboard',
         staticQueryParams: {
-          fromBreadcrumb: true,
+          'from-breadcrumb': true,
         },
       },
     },
@@ -44,7 +44,7 @@ export const appRoutes: Routes = [
       breadcrumb: {
         info: 'person',
         staticQueryParams: {
-          fromBreadcrumb: true,
+          'from-breadcrumb': true,
         },
       },
     },
@@ -58,7 +58,7 @@ export const appRoutes: Routes = [
         info: 'person_outline',
         label: 'Mentee (Root)',
         staticQueryParams: {
-          fromBreadcrumb: true,
+          'from-breadcrumb': true,
         },
       },
     },

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -10,6 +10,7 @@
   - [Custom styles](custom-styles.md)
   - [Disable breadcrumb navigation](disable-breadcrumb-navigation.md)
   - [Intercept breadcrumb onclick](intercept-breadcrumb-onclick.md)
+  - [Pass query parameters to route](static-query-params.md)
 
 - Customization
 

--- a/docs/static-query-params.md
+++ b/docs/static-query-params.md
@@ -1,0 +1,18 @@
+# Add static query parameters
+
+You can add fixed value query parameters to route navigated from breadcrumb click using property `staticQueryParams`.
+Typical use case is when navigating via breadcrumb has some sort of side effect.
+
+```javascript
+  {
+    path: 'edit',
+    component: MentorEditComponent,
+    data: {
+      breadcrumb: {
+        staticQueryParams: {
+          'show-side-nav': false
+        }
+      }
+    }
+  }
+```

--- a/libs/xng-breadcrumb/src/lib/breadcrumb.component.html
+++ b/libs/xng-breadcrumb/src/lib/breadcrumb.component.html
@@ -22,9 +22,7 @@
               ? breadcrumb.routeInterceptor(breadcrumb.routeLink, breadcrumb)
               : breadcrumb.routeLink
           "
-          [queryParams]="
-            preserveQueryParams ? breadcrumb.queryParams : undefined
-          "
+          [queryParams]="getQueryParams(breadcrumb)"
           [fragment]="preserveFragment ? breadcrumb.fragment : undefined"
           [target]="anchorTarget ? anchorTarget : '_self'"
         >

--- a/libs/xng-breadcrumb/src/lib/breadcrumb.component.ts
+++ b/libs/xng-breadcrumb/src/lib/breadcrumb.component.ts
@@ -6,7 +6,7 @@ import {
   TemplateRef,
   ViewEncapsulation,
 } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Params } from '@angular/router';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { BreadcrumbItemDirective } from './breadcrumb-item.directive';
@@ -100,6 +100,17 @@ export class BreadcrumbComponent implements OnInit {
   setupComponent(someParam) {
     this.setupMessage = 'set up at ' + new Date();
     this.someParameterValue = someParam;
+  }
+
+  getQueryParams(breadcrumb: BreadcrumbDefinition) {
+    let res: Params = {};
+    if (breadcrumb.staticQueryParams) {
+      res = { ...breadcrumb.staticQueryParams };
+    }
+    if (this.preserveQueryParams && breadcrumb.queryParams) {
+      res = { ...res, ...breadcrumb.queryParams };
+    }
+    return res;
   }
 
   ngOnInit() {

--- a/libs/xng-breadcrumb/src/lib/types/breadcrumb.config.ts
+++ b/libs/xng-breadcrumb/src/lib/types/breadcrumb.config.ts
@@ -1,4 +1,5 @@
 import { Breadcrumb } from './breadcrumb';
+import { Params } from '@angular/router';
 
 /**
  * Breadcrumb config provided as part of App Route Config
@@ -30,6 +31,10 @@ export interface BreadcrumbObject {
    * Consumers can change the breadcrumb routing dynamically with this approach
    */
   routeInterceptor?: (routeLink: string, breadcrumb: Breadcrumb) => string;
+  /**
+   * Query parameters that will be always passed to route when using breadcrumb.
+   */
+  staticQueryParams?: Params;
 }
 
 // resolved label for a route can further be enhanced based on a function

--- a/libs/xng-breadcrumb/src/lib/types/breadcrumb.ts
+++ b/libs/xng-breadcrumb/src/lib/types/breadcrumb.ts
@@ -1,3 +1,5 @@
+import { Params } from '@angular/router';
+
 /**
  * Breadcrumb item built internally, private to this module
  */
@@ -20,7 +22,7 @@ export interface Breadcrumb {
   /**
    * Query params in string form.
    */
-  queryParams?: unknown;
+  queryParams?: Params;
   fragment?: string;
   routeInterceptor?: (routeLink: string, breadcrumb: Breadcrumb) => string;
 }


### PR DESCRIPTION
# What is this PR about

Static query params passed into `routerLink` while navigating using `xng-breadcrumb`. Useful when you need to distinguish between navigating from `xng-breadcrumb` and other `routerLink`.

## PR Checklist

- [x] The commit message follows [the guidelines](./contributing.md#commit)
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
