### PR TITLE
feat: add option to show breadcrumbs for empty path routes

### DIFF
--- a/apps/material-ui-e2e/src/base.spec.ts
+++ b/apps/material-ui-e2e/src/base.spec.ts
@@ -88,3 +88,18 @@ test('not preserve query params if disabled', async ({ basePage }) => {
 
   await expect(basePage.advancedBreadcrumbs1.getByRole('link', { name: 'Enabler' })).toHaveAttribute('href', '/mentor#testFragment');
 });
+
+test('show breadcrumb also for empty path child when force is set to true', async ({ basePage }) => {
+  await basePage.navigateToConnect();
+
+  await expect(basePage.defaultBreadcrumbs).toHaveText('app/connect/connect (child)');
+  await expect(basePage.customBreadcrumbs).toHaveText('App ~ Connect ~ Connect (Child)');
+});
+
+test('show breadcrumb for route that is using matcher when force is set to true', async ({ basePage }) => {
+  await basePage.navigateToConnect();
+  await basePage.clickConnectButton();
+
+  await expect(basePage.defaultBreadcrumbs).toHaveText('app/connect/connect (child)/Connect Success');
+  await expect(basePage.customBreadcrumbs).toHaveText('App ~ Connect ~ Connect (Child) ~ Connect Success');
+});

--- a/apps/material-ui-e2e/src/page.ts
+++ b/apps/material-ui-e2e/src/page.ts
@@ -34,4 +34,12 @@ export class BasePage {
   async editMember() {
     await this.page.getByRole('button', { name: 'Edit' }).click();
   }
+
+  async navigateToConnect() {
+    await this.page.getByRole('link', { name: 'Connect' }).click();
+  }
+
+  async clickConnectButton() {
+    this.page.getByRole('button', { name: 'Connect' }).click();
+  }
 }

--- a/apps/material-ui/src/app/connect/connect.routes.ts
+++ b/apps/material-ui/src/app/connect/connect.routes.ts
@@ -6,9 +6,23 @@ export const CONNECT_ROUTES: Route[] = [
   {
     path: '',
     component: ConnectComponent,
-  },
-  {
-    path: 'connect-success',
-    component: ConnectSuccessComponent,
+    data: {
+      breadcrumb: {
+        label: 'connect (child)',
+        force: true,
+      },
+    },
+    children: [
+      {
+        matcher: (url) => (url.length === 1 && url[0].path === 'connect-success' ? { consumed: url } : null),
+        component: ConnectSuccessComponent,
+        data: {
+          breadcrumb: {
+            label: 'Connect Success',
+            force: true,
+          },
+        },
+      },
+    ],
   },
 ];

--- a/xng-breadcrumb/src/lib/breadcrumb.service.ts
+++ b/xng-breadcrumb/src/lib/breadcrumb.service.ts
@@ -92,7 +92,7 @@ export class BreadcrumbService {
 
   private prepareBreadcrumbItem(activatedRouteSnapshot: ActivatedRouteSnapshot, routeLinkPrefix: string): BreadcrumbDefinition {
     const { path, breadcrumb } = this.parseRouteData(activatedRouteSnapshot.routeConfig);
-    const resolvedSegment = this.resolvePathSegment(path, activatedRouteSnapshot);
+    const resolvedSegment = this.resolvePathSegment(path ?? '', activatedRouteSnapshot);
     const routeLink = `${routeLinkPrefix}${resolvedSegment}`;
     const storeItem = this.getFromStore(breadcrumb.alias, routeLink);
 
@@ -115,7 +115,7 @@ export class BreadcrumbService {
   }
 
   private prepareBreadcrumbList(activatedRouteSnapshot: ActivatedRouteSnapshot, routeLinkPrefix: string): Breadcrumb[] | void {
-    if (activatedRouteSnapshot.routeConfig?.path) {
+    if (activatedRouteSnapshot.routeConfig?.path || activatedRouteSnapshot.routeConfig?.data?.['breadcrumb']?.force) {
       const breadcrumbItem = this.prepareBreadcrumbItem(activatedRouteSnapshot, routeLinkPrefix);
       this.currentBreadcrumbs.push(breadcrumbItem);
 
@@ -205,7 +205,7 @@ export class BreadcrumbService {
 
   /**
    * get empty children of a module or Component. Empty child is the one with path: ''
-   * When parent and it's children (that has empty route path) define data merge them both with child taking precedence
+   * When parent and its children (that has empty route path) define data merge them both with child taking precedence (if child has force set to true do not merge)
    */
   private mergeWithBaseChildData(
     routeConfig: any, // TODO: add proper type
@@ -225,7 +225,7 @@ export class BreadcrumbService {
     }
 
     const childConfig = baseChild?.data?.breadcrumb;
-    return childConfig
+    return childConfig && !childConfig.force
       ? this.mergeWithBaseChildData(baseChild, {
           ...this.extractObject(config),
           ...this.extractObject(childConfig),

--- a/xng-breadcrumb/src/lib/types.ts
+++ b/xng-breadcrumb/src/lib/types.ts
@@ -58,6 +58,10 @@ export interface BreadcrumbObject {
    * Consumers can change the breadcrumb routing dynamically with this approach
    */
   routeInterceptor?: (routeLink: string, breadcrumb: Breadcrumb) => string;
+  /**
+   * force show the breadcrumb item even if path is empty
+   */
+  force?: boolean;
 }
 
 // resolved label for a route can further be enhanced based on a function


### PR DESCRIPTION
Currently, if there is an empty path child route (it can be that the route is using `matcher` instead of `path`), its breadcrumb is not rendered as a separate breadcrumb, but instead, it replaces parent route breadcrumb.

This PR introduces breadcrumb option `force`, when set to `true`, it forces breadcrumb of an empty path route to be rendered as a separate one.

To illustrate on an example:

```ts
export const ROUTES: Route[] = [
  {
    path: 'sample',
    component: SampleComponent,
    data: {
      breadcrumb: {
        label: 'Sample Component',
      },
    },
    children: [
      {
        matcher: (url) => (url.length === 1 && url[0].path === 'hello-world' ? { consumed: url } : null),
        component: HelloWorldComponent,
        data: {
          breadcrumb: {
            label: 'Hello World',
            force: true, // note the force option
          },
        },
      },
    ],
  },
];
```

Currently, the breadcrumbs for this route structure when visiting `/sample/hello-world` route looks like this: `Sample Component`. With this PR it will look like this: `Sample Component / Hello World`.

Resolves #148 and #199 in a non-breaking way.