### PR TITLE
feat: ability to skip current route's breadcrumb

### DIFF
--- a/xng-breadcrumb/src/lib/breadcrumb.service.ts
+++ b/xng-breadcrumb/src/lib/breadcrumb.service.ts
@@ -129,9 +129,21 @@ export class BreadcrumbService {
     this.setQueryParamsForActiveBreadcrumb(lastCrumb, activatedRouteSnapshot);
 
     // remove breadcrumb items that needs to be hidden
-    const breadcrumbsToShow = this.currentBreadcrumbs.filter((item) => !item.skip);
+    const breadcrumbsToShow = this.currentBreadcrumbs.filter((item) => {
+      if (item.skipSelf) {
+        return !this.shouldSkipSelf(item.routeLink ?? '');
+      }
+
+      return !item.skip;
+    });
 
     this.breadcrumbs.next(breadcrumbsToShow);
+  }
+
+  private shouldSkipSelf(path: string): boolean {
+    const finalUrl = this.router.getCurrentNavigation()?.finalUrl?.toString() ?? '';
+    const [withoutQueryParams] = finalUrl.split('?');
+    return withoutQueryParams.endsWith(path) ?? false;
   }
 
   private getFromStore(alias: string, routeLink: string): BreadcrumbDefinition {

--- a/xng-breadcrumb/src/lib/types.ts
+++ b/xng-breadcrumb/src/lib/types.ts
@@ -45,6 +45,10 @@ export interface BreadcrumbObject {
    */
   skip?: boolean;
   /**
+   * hide a breadcrumb of the current route
+   */
+  skipSelf?: boolean;
+  /**
    * disable a certain breadcrumb in the list. Not clickable.
    * It may be needed when the routing has the path, but navigating to that path is of no use
    */


### PR DESCRIPTION
# What is this PR about

This PR adds an ability to skip breadcrumbs for the current route because usually people use breadcrumbs as a navigation tool to go **back** into previous pages.

How it works:

```ts
const routes = [
  {
     path: 'users',
     data: { breadcrumb: {skipSelf: true} },
     children: [
        {
           path: ':id',
           data: { breadcrumb: {skipSelf: true} }
        }
     ]
  }
]
```

Url: `/users`
Visible breadcrumbs (simplified): `[]` - `Users` breadcrumb is hidden.

Url: `/users/:id`
Visible breadcrumbs (simplified): `[{label: 'Users'}]` - now the `Users` breadcrumb is visible so it is possible to go back to users page from a specific user.

And the same logic applies for `/users/:id/edit` and etc.

## PR Checklist

Please check if your PR fulfils the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] The commit message follows [the guidelines](./contributing.md#commit)
