### PR TITLE
fix(lib): changed rxjs map import from rxjs to rxjs/operators

### DIFF
--- a/xng-breadcrumb/src/lib/breadcrumb.component.ts
+++ b/xng-breadcrumb/src/lib/breadcrumb.component.ts
@@ -1,7 +1,8 @@
 import { Component, ContentChild, Input, OnInit, TemplateRef, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
-import { Observable, map } from 'rxjs';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { BreadcrumbItemDirective } from './breadcrumb-item.directive';
 import { BreadcrumbService } from './breadcrumb.service';
 import { BreadcrumbDefinition } from './types';


### PR DESCRIPTION
# What is this PR about
![image](https://github.com/user-attachments/assets/d6fb7c27-bd13-4b8c-8d45-f71c1bc466e9)

While trying to serve my app I am getting an error ( see picture above ). After a close look at the libs source code I have noticed that there is a wrong import. Map operator should be imported from the rxjs/operators instead of rxjs.

## PR Checklist

Please check if your PR fulfils the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
       Changing 1 line of import doesnt require new tests to be introduced.
- [ ] Docs have been added/updated (for bug fixes/features)
      No new features have been added
- [x] The commit message follows [the guidelines](./contributing.md#commit)
