### PR TITLE
fix: fixed missing types export (#224)

### DIFF
--- a/xng-breadcrumb/src/index.ts
+++ b/xng-breadcrumb/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/breadcrumb.component';
 export * from './lib/breadcrumb-item.directive';
 export * from './lib/breadcrumb.service';
+export * from './lib/types';


### PR DESCRIPTION
# What is this PR about

This PR added missing type imports so that ex. `BreadcrumbDefinition` can be imported when using the library.
Fixes #224

## PR Checklist

Please check if your PR fulfils the following requirements:

- [ not relevant] Tests for the changes have been added (for bug fixes/features)
- [not relevant ] Docs have been added/updated (for bug fixes/features)
- [x] The commit message follows [the guidelines](./contributing.md#commit)
